### PR TITLE
feat: v0.0.6 (improved sidebar, optional Dashboard API, indices autocomplete, better copy of strings in JSON)

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -18,6 +18,11 @@ module.exports = {
       version: 'detect',
     },
   },
+  parser: '@typescript-eslint/parser',
+  parserOptions: {
+    project: ['./tsconfig.json'],
+    tsconfigRootDir: __dirname,
+  },
   rules: {
     '@typescript-eslint/indent': 'off',
     '@typescript-eslint/no-unused-vars': [
@@ -35,6 +40,8 @@ module.exports = {
         selector: 'interface',
       },
     ],
+    '@typescript-eslint/switch-exhaustiveness-check': 'error',
+    'default-case': 'off',
     'no-console': ['error', { allow: ['info'] }],
     'prettier/prettier': ['error', {}, { usePrettierrc: true }],
     'react/react-in-jsx-scope': 'off',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "algolia-analyzer",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "author": "Emmanuel Krebs <e-krebs@users.noreply.github.com>",
   "license": "MIT",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "@types/node": "^18.6.2",
     "@types/react": "^18.0.15",
     "@types/react-dom": "^18.0.6",
+    "@typescript-eslint/parser": "^5.61.0",
     "algoliasearch": "^4.14.2",
     "autoprefixer": "^10.4.8",
     "bestzip": "^2.2.1",

--- a/src/components/Code.tsx
+++ b/src/components/Code.tsx
@@ -5,11 +5,14 @@ import JsonView from 'react-json-view';
 interface CodeProps {
   code?: unknown;
   leftPadding?: boolean;
+  className?: string;
 }
 
-export const Code: FC<CodeProps> = ({ code, leftPadding = true }) =>
+export const Code: FC<CodeProps> = ({ code, leftPadding = true, className }) =>
   code ? (
-    <div className={cx('py-2 break-all overflow-x-hidden bg-white', leftPadding && 'pl-6')}>
+    <div
+      className={cx('py-2 break-all overflow-x-hidden bg-white', leftPadding && 'pl-6', className)}
+    >
       <JsonView
         src={code as Record<string, unknown>}
         name={null}

--- a/src/components/Code.tsx
+++ b/src/components/Code.tsx
@@ -1,12 +1,30 @@
 import cx from 'classnames';
 import type { FC } from 'react';
-import JsonView from 'react-json-view';
+import JsonView, { type OnCopyProps } from 'react-json-view';
 
 interface CodeProps {
   code?: unknown;
   leftPadding?: boolean;
   className?: string;
 }
+
+const copyToClipboard = ({ src }: OnCopyProps): void => {
+  const container = document.createElement('textarea');
+
+  switch (typeof src) {
+    case 'string':
+      container.innerHTML = src;
+      break;
+    default:
+      container.innerHTML = JSON.stringify(src, null, 2);
+      break;
+  }
+
+  document.body.appendChild(container);
+  container.select();
+  document.execCommand('copy');
+  document.body.removeChild(container);
+};
 
 export const Code: FC<CodeProps> = ({ code, leftPadding = true, className }) =>
   code ? (
@@ -22,6 +40,7 @@ export const Code: FC<CodeProps> = ({ code, leftPadding = true, className }) =>
         displayDataTypes={false}
         quotesOnKeys={false}
         style={{ fontSize: '12px' }}
+        enableClipboard={copyToClipboard}
       />
     </div>
   ) : null;

--- a/src/components/RequestsGrid/FilteringOption.ts
+++ b/src/components/RequestsGrid/FilteringOption.ts
@@ -1,0 +1,30 @@
+import { type Option } from '@algolia/satellite';
+
+export const generalTypes = ['method', 'statusCode'] as const;
+type GeneralOptionType = typeof generalTypes[number];
+
+export interface GeneralOption extends Option {
+  type: GeneralOptionType;
+  reversed: boolean;
+}
+
+export const urlTypes = ['cluster', 'index', 'apiSubPath', 'api'] as const;
+type UrlOptionType = typeof urlTypes[number];
+
+export interface UrlOption extends Option {
+  type: UrlOptionType;
+  reversed: boolean;
+}
+
+export const allFilterTypes = [...generalTypes, ...urlTypes] as const;
+export type FilterType = GeneralOptionType | UrlOptionType;
+export type FilteringOption = GeneralOption | UrlOption;
+
+export const noValueText: Record<FilterType, `no ${string}`> = {
+  api: 'no API',
+  apiSubPath: 'no API path',
+  cluster: 'no cluster',
+  index: 'no index',
+  method: 'no method',
+  statusCode: 'no status code',
+};

--- a/src/components/RequestsGrid/GeneralOption.tsx
+++ b/src/components/RequestsGrid/GeneralOption.tsx
@@ -1,13 +1,9 @@
-import type { Option } from '@algolia/satellite';
 import cx from 'classnames';
 import { type FC, type MouseEventHandler } from 'react';
 
 import { type CustomTagProps, MethodTag, StatusCodeTag } from 'components/Tags';
 
-export interface GeneralOption extends Option {
-  type: 'method' | 'statusCode';
-  reversed: boolean;
-}
+import { type GeneralOption } from './FilteringOption';
 
 interface GeneralOptionItemComponentProps {
   option: GeneralOption;
@@ -35,7 +31,7 @@ export const GeneralOptionItemComponent: FC<GeneralOptionItemComponentProps> = (
     onClick,
   };
 
-  switch ((option as GeneralOption).type) {
+  switch (option.type) {
     case 'method':
       return <MethodTag {...props} method={option.value as string} />;
     case 'statusCode':

--- a/src/components/RequestsGrid/RequestLine.tsx
+++ b/src/components/RequestsGrid/RequestLine.tsx
@@ -31,16 +31,13 @@ export const RequestLine: FC<LineProps> = ({ request }) => {
       className={cx('group', selectedLine?.id === id && 'bg-grey-100')}
       onClick={onClick}
     >
-      <td className="whitespace-nowrap space-x-1 group-hover:bg-grey-100">
+      <td className="space-x-1 leading-lg group-hover:bg-grey-100">
         <MethodTag method={method} />
         <StatusCodeTag statusCode={statusCode} />
         <span>{Math.round(time)} ms</span>
       </td>
       <td
-        className={cx(
-          'space-x-1 leading-lg group-hover:bg-grey-100',
-          selectedLine?.id !== id && 'truncate'
-        )}
+        className={cx('space-x-1 leading-lg group-hover:bg-grey-100', !selectedLine && 'truncate')}
       >
         {cluster && <ClusterTag cluster={cluster} />}
         {api && <ApiTag api={api} />}

--- a/src/components/RequestsGrid/RequestLine.tsx
+++ b/src/components/RequestsGrid/RequestLine.tsx
@@ -3,7 +3,7 @@ import { type FC, useCallback } from 'react';
 
 import { useSidebar } from 'components/SidebarContent';
 import {
-  SubPathTag,
+  ApiSubPathTag,
   ClusterTag,
   IndexTag,
   ApiTag,
@@ -17,7 +17,7 @@ interface LineProps {
 }
 
 export const RequestLine: FC<LineProps> = ({ request }) => {
-  const { id, method, statusCode, time, url, displayableUrl, cluster, subPath, index, api } =
+  const { id, method, statusCode, time, url, displayableUrl, cluster, apiSubPath, index, api } =
     request;
   const { selectedLine, setSelectedLine } = useSidebar();
 
@@ -45,7 +45,7 @@ export const RequestLine: FC<LineProps> = ({ request }) => {
         {cluster && <ClusterTag cluster={cluster} />}
         {api && <ApiTag api={api} />}
         {index && <IndexTag index={index} />}
-        {subPath && <SubPathTag subPath={subPath} />}
+        {apiSubPath && <ApiSubPathTag subPath={apiSubPath} />}
         {!selectedLine && (
           <span title={decodeURIComponent(url)} className="px-1">
             {displayableUrl}

--- a/src/components/RequestsGrid/RequestLine.tsx
+++ b/src/components/RequestsGrid/RequestLine.tsx
@@ -1,5 +1,5 @@
 import cx from 'classnames';
-import { type FC, useCallback } from 'react';
+import { type FC } from 'react';
 
 import { useSidebar } from 'components/SidebarContent';
 import {
@@ -19,17 +19,13 @@ interface LineProps {
 export const RequestLine: FC<LineProps> = ({ request }) => {
   const { id, method, statusCode, time, url, displayableUrl, cluster, apiSubPath, index, api } =
     request;
-  const { selectedLine, setSelectedLine } = useSidebar();
-
-  const onClick = useCallback(() => {
-    setSelectedLine(request);
-  }, [request, setSelectedLine]);
+  const { selectedLine, selectLine } = useSidebar();
 
   return (
     <tr
       key={id}
       className={cx('group', selectedLine?.id === id && 'bg-grey-100')}
-      onClick={onClick}
+      onClick={(): void => selectLine(request)}
     >
       <td className="space-x-1 leading-lg group-hover:bg-grey-100">
         <MethodTag method={method} />

--- a/src/components/RequestsGrid/RequestsGrid.tsx
+++ b/src/components/RequestsGrid/RequestsGrid.tsx
@@ -16,10 +16,9 @@ import { HelpCircle, Search } from 'react-feather';
 import { useSidebar } from 'components/SidebarContent';
 import { getLocalStorageValue, setLocalStorageValue, type Request, type ApiType } from 'utils';
 
-import type { GeneralOption } from './GeneralOption';
+import { type GeneralOption, type UrlOption } from './FilteringOption';
 import { GeneralOptionItemComponent } from './GeneralOption';
 import { RequestLine } from './RequestLine';
-import type { UrlOption } from './UrlOption';
 import { UrlOptionItemComponent } from './UrlOption';
 
 interface RequestsGridProps {

--- a/src/components/RequestsGrid/RequestsGrid.tsx
+++ b/src/components/RequestsGrid/RequestsGrid.tsx
@@ -6,7 +6,6 @@ import {
   Medallion,
   TooltipWrapper,
 } from '@algolia/satellite';
-import cx from 'classnames';
 import isEqual from 'lodash/isEqual';
 import { type FC, useCallback, useEffect, useMemo, useState } from 'react';
 import { HelpCircle, Search } from 'react-feather';
@@ -137,7 +136,7 @@ export const RequestsGrid: FC<RequestsGridProps> = ({ requests }) => {
         <table className="stl-table-with-highlight stl-table table-fixed">
           <thead>
             <tr className="capitalize">
-              <th className={cx('!font-bold', selectedLine === undefined ? 'w-48' : 'w-32')}>
+              <th className="!font-bold w-48">
                 general <ReverseTagInfo />
               </th>
               <th className="!font-bold">

--- a/src/components/RequestsGrid/RequestsGrid.tsx
+++ b/src/components/RequestsGrid/RequestsGrid.tsx
@@ -7,19 +7,25 @@ import {
   TooltipWrapper,
 } from '@algolia/satellite';
 import cx from 'classnames';
-import concat from 'lodash/concat';
 import isEqual from 'lodash/isEqual';
-import uniq from 'lodash/uniq';
 import { type FC, useCallback, useEffect, useMemo, useState } from 'react';
 import { HelpCircle, Search } from 'react-feather';
 
 import { useSidebar } from 'components/SidebarContent';
-import { getLocalStorageValue, setLocalStorageValue, type Request, type ApiType } from 'utils';
+import { getLocalStorageValue, setLocalStorageValue, type Request } from 'utils';
 
-import { type GeneralOption, type UrlOption } from './FilteringOption';
+import {
+  allFilterTypes,
+  generalTypes,
+  type GeneralOption,
+  type UrlOption,
+  urlTypes,
+} from './FilteringOption';
 import { GeneralOptionItemComponent } from './GeneralOption';
 import { RequestLine } from './RequestLine';
 import { UrlOptionItemComponent } from './UrlOption';
+import { filterByType } from './filterByType';
+import { getOptions } from './getOptions';
 
 interface RequestsGridProps {
   requests: Request[];
@@ -75,162 +81,23 @@ export const RequestsGrid: FC<RequestsGridProps> = ({ requests }) => {
   }, [defaultGeneralOptions, defaultUrlOptions, selectedGeneralOptions, selectedUrlOptions]);
 
   const selectedRequests = useMemo(() => {
+    const allOptions = [...selectedGeneralOptions, ...selectedUrlOptions];
     let filteredRequests = requests;
-    const selectedMethods: string[] = selectedGeneralOptions
-      .filter((o) => o.type === 'method' && !o.reversed)
-      .map((o) => o.value as string);
-    const reverseSelectedMethods: string[] = selectedGeneralOptions
-      .filter((o) => o.type === 'method' && o.reversed)
-      .map((o) => o.value as string);
-    if (selectedMethods.length > 0) {
-      filteredRequests = filteredRequests.filter((r) => selectedMethods.includes(r.method));
-    }
-    if (reverseSelectedMethods.length > 0) {
-      filteredRequests = filteredRequests.filter((r) => !reverseSelectedMethods.includes(r.method));
-    }
-
-    const selectedStatusCodes: number[] = selectedGeneralOptions
-      .filter((o) => o.type === 'statusCode' && !o.reversed)
-      .map((o) => o.value as number);
-    const reverseSelectedStatusCodes: number[] = selectedGeneralOptions
-      .filter((o) => o.type === 'statusCode' && o.reversed)
-      .map((o) => o.value as number);
-    if (selectedStatusCodes.length > 0) {
-      filteredRequests = filteredRequests.filter((r) => selectedStatusCodes.includes(r.statusCode));
-    }
-    if (reverseSelectedStatusCodes.length > 0) {
-      filteredRequests = filteredRequests.filter(
-        (r) => !reverseSelectedStatusCodes.includes(r.statusCode)
-      );
-    }
-
-    const selectedClusters: string[] = selectedUrlOptions
-      .filter((o) => o.type === 'cluster' && !o.reversed)
-      .map((o) => o.value as string);
-    const reversedSelectedClusters: string[] = selectedUrlOptions
-      .filter((o) => o.type === 'cluster' && o.reversed)
-      .map((o) => o.value as string);
-    if (selectedClusters.length > 0) {
-      filteredRequests = filteredRequests.filter(
-        (r) => r.cluster && selectedClusters.includes(r.cluster)
-      );
-    }
-    if (reversedSelectedClusters.length > 0) {
-      filteredRequests = filteredRequests.filter(
-        (r) => !r.cluster || !reversedSelectedClusters.includes(r.cluster)
-      );
-    }
-
-    const selectedApis: ApiType[] = selectedUrlOptions
-      .filter((o) => o.type === 'api' && !o.reversed)
-      .map((o) => (o.value ?? null) as ApiType);
-    const reversedSelectedApis: ApiType[] = selectedUrlOptions
-      .filter((o) => o.type === 'api' && o.reversed)
-      .map((o) => (o.value ?? null) as ApiType);
-    if (selectedApis.length > 0) {
-      filteredRequests = filteredRequests.filter((r) => selectedApis.includes(r.api));
-    }
-    if (reversedSelectedApis.length > 0) {
-      filteredRequests = filteredRequests.filter((r) => !reversedSelectedApis.includes(r.api));
-    }
-
-    const selectedIndices: Array<string | null> = selectedUrlOptions
-      .filter((o) => o.type === 'index' && !o.reversed)
-      .map((o) => (o.value ?? null) as string | null);
-    const reversedSelectedIndices: Array<string | null> = selectedUrlOptions
-      .filter((o) => o.type === 'index' && o.reversed)
-      .map((o) => (o.value ?? null) as string | null);
-    if (selectedIndices.length > 0) {
-      filteredRequests = filteredRequests.filter(
-        (r) =>
-          (!r.index && selectedIndices.find((i) => !i) !== undefined) || // selected index is "no index"
-          selectedIndices.includes(r.index)
-      );
-    }
-    if (reversedSelectedIndices.length > 0) {
-      filteredRequests = filteredRequests.filter((r) =>
-        !r.index
-          ? reversedSelectedIndices.find((i) => !i) === undefined // selected index is !"no index"
-          : !reversedSelectedIndices.includes(r.index)
-      );
-    }
-
-    const selectedSubPaths: Array<string | null> = selectedUrlOptions
-      .filter((o) => o.type === 'apiSubPath' && !o.reversed)
-      .map((o) => (o.value ?? null) as string | null);
-    const reversedSelectedSubPaths: Array<string | null> = selectedUrlOptions
-      .filter((o) => o.type === 'apiSubPath' && o.reversed)
-      .map((o) => (o.value ?? null) as string | null);
-    if (selectedSubPaths.length > 0) {
-      filteredRequests = filteredRequests.filter(
-        (r) =>
-          (!r.apiSubPath && selectedSubPaths.find((i) => !i) !== undefined) || // selected subPath is "no apiSupPath"
-          selectedSubPaths.includes(r.apiSubPath)
-      );
-    }
-    if (reversedSelectedSubPaths.length > 0) {
-      filteredRequests = filteredRequests.filter((r) =>
-        !r.apiSubPath
-          ? reversedSelectedSubPaths.find((i) => !i) === undefined // selected subPath is !"no apiSupPath"
-          : !reversedSelectedSubPaths.includes(r.apiSubPath)
-      );
+    for (const type of allFilterTypes) {
+      filteredRequests = filterByType(filteredRequests, allOptions, type);
     }
     return filteredRequests;
   }, [requests, selectedGeneralOptions, selectedUrlOptions]);
 
-  const generalOptions: GeneralOption[] = useMemo(() => {
-    const methods = uniq(selectedRequests.map((r) => r.method));
-    const statusCodes = uniq(selectedRequests.map((r) => r.statusCode));
-    return concat<GeneralOption>(
-      methods.map((method) => ({
-        value: method,
-        label: method,
-        type: 'method',
-        reversed: false,
-      })),
-      statusCodes.map((code) => ({
-        value: code,
-        label: code.toString(),
-        type: 'statusCode',
-        reversed: false,
-      }))
-    );
-  }, [selectedRequests]);
+  const generalOptions = useMemo(
+    () => getOptions<GeneralOption>(selectedRequests, generalTypes),
+    [selectedRequests]
+  );
 
-  const urlOptions: UrlOption[] = useMemo(() => {
-    const clusters = uniq(
-      selectedRequests.filter((r) => r.cluster).map((r) => r.cluster)
-    ) as string[];
-    const indices = uniq(selectedRequests.map((r) => r.index));
-    const subPaths = uniq(selectedRequests.map((r) => r.apiSubPath));
-    const apis = uniq(selectedRequests.map((r) => r.api));
-    return concat<UrlOption>(
-      clusters.map((cluster) => ({
-        value: cluster,
-        label: cluster,
-        type: 'cluster',
-        reversed: false,
-      })),
-      indices.map((index) => ({
-        value: index ?? '',
-        label: index ?? 'no index',
-        type: 'index',
-        reversed: false,
-      })),
-      subPaths.map((subPath) => ({
-        value: subPath ?? '',
-        label: subPath ?? 'no API path',
-        type: 'apiSubPath',
-        reversed: false,
-      })),
-      apis.map((api) => ({
-        value: api,
-        label: api,
-        type: 'api',
-        reversed: false,
-      }))
-    );
-  }, [selectedRequests]);
+  const urlOptions = useMemo(
+    () => getOptions<UrlOption>(selectedRequests, urlTypes),
+    [selectedRequests]
+  );
 
   const deleteGeneralOption = useCallback(
     (option: GeneralOption) =>
@@ -270,7 +137,7 @@ export const RequestsGrid: FC<RequestsGridProps> = ({ requests }) => {
         <table className="stl-table-with-highlight stl-table table-fixed">
           <thead>
             <tr className="capitalize">
-              <th className={cx('!font-bold', selectedLine === undefined && 'w-48')}>
+              <th className={cx('!font-bold', selectedLine === undefined ? 'w-48' : 'w-32')}>
                 general <ReverseTagInfo />
               </th>
               <th className="!font-bold">
@@ -279,27 +146,32 @@ export const RequestsGrid: FC<RequestsGridProps> = ({ requests }) => {
             </tr>
             <tr>
               <th>
-                <AutoComplete
-                  multiple={true}
-                  options={generalOptions}
-                  value={selectedGeneralOptions}
-                  optionItemComponent={GeneralOptionItemComponent}
-                  renderValueTemplate={(args): JSX.Element => (
-                    <GeneralOptionItemComponent
-                      {...args}
-                      deleteOption={deleteGeneralOption}
-                      reverseOption={reverseGeneralOption}
-                    />
-                  )}
-                  onChange={(options): void =>
-                    setSelectedGeneralOptions((options as GeneralOption[]) ?? [])
-                  }
-                />
+                <div className="flex items-baseline">
+                  <AutoComplete
+                    className="max-w-full"
+                    valuesClassName="max-w-full py-1.5"
+                    multiple={true}
+                    options={generalOptions}
+                    value={selectedGeneralOptions}
+                    optionItemComponent={GeneralOptionItemComponent}
+                    renderValueTemplate={(args): JSX.Element => (
+                      <GeneralOptionItemComponent
+                        {...args}
+                        deleteOption={deleteGeneralOption}
+                        reverseOption={reverseGeneralOption}
+                      />
+                    )}
+                    onChange={(options): void =>
+                      setSelectedGeneralOptions((options as GeneralOption[]) ?? [])
+                    }
+                  />
+                </div>
               </th>
               <th>
                 <div className="flex space-x-2 items-baseline">
                   <AutoComplete
                     className="grow"
+                    valuesClassName="py-1.5"
                     multiple={true}
                     options={urlOptions}
                     value={selectedUrlOptions}

--- a/src/components/RequestsGrid/RequestsGrid.tsx
+++ b/src/components/RequestsGrid/RequestsGrid.tsx
@@ -164,15 +164,15 @@ export const RequestsGrid: FC<RequestsGridProps> = ({ requests }) => {
     if (selectedSubPaths.length > 0) {
       filteredRequests = filteredRequests.filter(
         (r) =>
-          (!r.subPath && selectedSubPaths.find((i) => !i) !== undefined) || // selected subPath is "no apiSupPath"
-          selectedSubPaths.includes(r.subPath)
+          (!r.apiSubPath && selectedSubPaths.find((i) => !i) !== undefined) || // selected subPath is "no apiSupPath"
+          selectedSubPaths.includes(r.apiSubPath)
       );
     }
     if (reversedSelectedSubPaths.length > 0) {
       filteredRequests = filteredRequests.filter((r) =>
-        !r.subPath
+        !r.apiSubPath
           ? reversedSelectedSubPaths.find((i) => !i) === undefined // selected subPath is !"no apiSupPath"
-          : !reversedSelectedSubPaths.includes(r.subPath)
+          : !reversedSelectedSubPaths.includes(r.apiSubPath)
       );
     }
     return filteredRequests;
@@ -202,7 +202,7 @@ export const RequestsGrid: FC<RequestsGridProps> = ({ requests }) => {
       selectedRequests.filter((r) => r.cluster).map((r) => r.cluster)
     ) as string[];
     const indices = uniq(selectedRequests.map((r) => r.index));
-    const subPaths = uniq(selectedRequests.map((r) => r.subPath));
+    const subPaths = uniq(selectedRequests.map((r) => r.apiSubPath));
     const apis = uniq(selectedRequests.map((r) => r.api));
     return concat<UrlOption>(
       clusters.map((cluster) => ({

--- a/src/components/RequestsGrid/RequestsGrid.tsx
+++ b/src/components/RequestsGrid/RequestsGrid.tsx
@@ -10,7 +10,6 @@ import isEqual from 'lodash/isEqual';
 import { type FC, useCallback, useEffect, useMemo, useState } from 'react';
 import { HelpCircle, Search } from 'react-feather';
 
-import { useSidebar } from 'components/SidebarContent';
 import { getLocalStorageValue, setLocalStorageValue, type Request } from 'utils';
 
 import {
@@ -45,7 +44,6 @@ export const RequestsGrid: FC<RequestsGridProps> = ({ requests }) => {
   const [defaultUrlOptions, setDefaultUrlOptions] = useState<UrlOption[]>([]);
   const [selectedGeneralOptions, setSelectedGeneralOptions] = useState<GeneralOption[]>([]);
   const [selectedUrlOptions, setSelectedUrlOptions] = useState<UrlOption[]>([]);
-  const { selectedLine } = useSidebar();
 
   useEffect(() => {
     getLocalStorageValue<GeneralOption[]>(generalOptionsKey).then((generalOptions) => {
@@ -188,18 +186,16 @@ export const RequestsGrid: FC<RequestsGridProps> = ({ requests }) => {
                       setSelectedUrlOptions((options as UrlOption[]) ?? [])
                     }
                   />
-                  {selectedLine === undefined && (
-                    <TooltipWrapper content="Save these filters as your default for when you open this Panel.">
-                      <Button
-                        variant="primary"
-                        loading={isSaving}
-                        disabled={!canSaveOptions}
-                        onClick={saveDefaultOptions}
-                      >
-                        Save
-                      </Button>
-                    </TooltipWrapper>
-                  )}
+                  <TooltipWrapper content="Save these filters as your default for when you open this Panel.">
+                    <Button
+                      variant="primary"
+                      loading={isSaving}
+                      disabled={!canSaveOptions}
+                      onClick={saveDefaultOptions}
+                    >
+                      Save
+                    </Button>
+                  </TooltipWrapper>
                 </div>
               </th>
             </tr>

--- a/src/components/RequestsGrid/UrlOption.tsx
+++ b/src/components/RequestsGrid/UrlOption.tsx
@@ -1,14 +1,10 @@
-import type { Option } from '@algolia/satellite';
 import cx from 'classnames';
 import type { FC, MouseEventHandler } from 'react';
 
 import { ApiSubPathTag, ClusterTag, type CustomTagProps, IndexTag, ApiTag } from 'components/Tags';
 import { type ApiType } from 'utils';
 
-export interface UrlOption extends Option {
-  type: 'api' | 'apiSubPath' | 'cluster' | 'index';
-  reversed: boolean;
-}
+import { type UrlOption } from './FilteringOption';
 
 interface UrlOptionItemComponentProps {
   option: UrlOption;
@@ -36,7 +32,7 @@ export const UrlOptionItemComponent: FC<UrlOptionItemComponentProps> = ({
     onClick,
   };
 
-  switch ((option as UrlOption).type) {
+  switch (option.type) {
     case 'cluster':
       return <ClusterTag {...props} cluster={option.value as string} />;
     case 'index':

--- a/src/components/RequestsGrid/UrlOption.tsx
+++ b/src/components/RequestsGrid/UrlOption.tsx
@@ -2,7 +2,7 @@ import type { Option } from '@algolia/satellite';
 import cx from 'classnames';
 import type { FC, MouseEventHandler } from 'react';
 
-import { SubPathTag, ClusterTag, type CustomTagProps, IndexTag, ApiTag } from 'components/Tags';
+import { ApiSubPathTag, ClusterTag, type CustomTagProps, IndexTag, ApiTag } from 'components/Tags';
 import { type ApiType } from 'utils';
 
 export interface UrlOption extends Option {
@@ -42,7 +42,7 @@ export const UrlOptionItemComponent: FC<UrlOptionItemComponentProps> = ({
     case 'index':
       return <IndexTag {...props} index={option.value as string | null} />;
     case 'apiSubPath':
-      return <SubPathTag {...props} subPath={option.value as string | null} />;
+      return <ApiSubPathTag {...props} subPath={option.value as string | null} />;
     case 'api':
       return <ApiTag {...props} api={option.value as ApiType} />;
     default:

--- a/src/components/RequestsGrid/filterByType.ts
+++ b/src/components/RequestsGrid/filterByType.ts
@@ -1,0 +1,75 @@
+import { type Request } from 'utils';
+
+import type { FilterType, FilteringOption } from './FilteringOption';
+
+type OptionsValue = boolean | number | string;
+
+export const filterByType = (
+  requests: Request[],
+  filters: FilteringOption[],
+  type: FilterType
+): Request[] => {
+  let filteredRequests = requests;
+
+  const selectedValues = filters.filter((o) => o.type === type && !o.reversed).map((o) => o.value);
+  const reverseSelectedValues = filters
+    .filter((o) => o.type === type && o.reversed)
+    .map((o) => o.value);
+
+  switch (type) {
+    // basic options: non nullable & non optional
+    case 'api':
+    case 'method':
+    case 'statusCode':
+      if (selectedValues.length > 0) {
+        filteredRequests = filteredRequests.filter((r) =>
+          selectedValues.includes(r[type] as OptionsValue)
+        );
+      }
+      if (reverseSelectedValues.length > 0) {
+        filteredRequests = filteredRequests.filter(
+          (r) => !reverseSelectedValues.includes(r[type] as OptionsValue)
+        );
+      }
+      break;
+    // optional options
+    case 'cluster':
+      if (selectedValues.length > 0) {
+        filteredRequests = filteredRequests.filter(
+          (r) => r[type] && selectedValues.includes(r[type] as OptionsValue)
+        );
+      }
+      if (reverseSelectedValues.length > 0) {
+        filteredRequests = filteredRequests.filter(
+          (r) => !r[type] || !reverseSelectedValues.includes(r[type] as OptionsValue)
+        );
+      }
+      break;
+    // nullable & non-optional options
+    // (& there is a "no apiSupPath/index" that is selectable)
+    case 'apiSubPath':
+    case 'index':
+      if (selectedValues.length > 0) {
+        const nullableSelectedValues = selectedValues.map(
+          (v) => v ?? null
+        ) as Array<OptionsValue | null>;
+        filteredRequests = filteredRequests.filter(
+          (r) =>
+            (!r[type] && nullableSelectedValues.find((i) => !i) !== undefined) || // selected subPath is "no apiSupPath/index"
+            nullableSelectedValues.includes(r[type] as OptionsValue | null)
+        );
+      }
+      if (reverseSelectedValues.length > 0) {
+        const nullableReversedSelectedValues = reverseSelectedValues.map(
+          (v) => v ?? null
+        ) as Array<OptionsValue | null>;
+        filteredRequests = filteredRequests.filter((r) =>
+          !r[type]
+            ? nullableReversedSelectedValues.find((i) => !i) === undefined // selected subPath is !"no apiSupPath/index"
+            : !nullableReversedSelectedValues.includes(r[type] as OptionsValue | null)
+        );
+      }
+      break;
+  }
+  return filteredRequests;
+};

--- a/src/components/RequestsGrid/getOptions.ts
+++ b/src/components/RequestsGrid/getOptions.ts
@@ -1,0 +1,22 @@
+import uniq from 'lodash/uniq';
+
+import { type Request } from 'utils';
+
+import { noValueText, type FilteringOption } from './FilteringOption';
+
+export const getOptions = <T extends FilteringOption>(
+  requests: Request[],
+  types: ReadonlyArray<T['type']>
+): T[] =>
+  types.flatMap((type) =>
+    uniq(requests.map((r) => r[type])).map((value) => {
+      // @ts-expect-error to improve
+      const option: T = {
+        value: value ?? '',
+        label: value ? value.toString() : noValueText[type],
+        type,
+        reversed: false,
+      };
+      return option;
+    })
+  );

--- a/src/components/SidebarContent/SidebarContent.tsx
+++ b/src/components/SidebarContent/SidebarContent.tsx
@@ -1,5 +1,5 @@
 import type { FC } from 'react';
-import { Upload, Download, Link2 } from 'react-feather';
+import { Upload, Download, Link2, X } from 'react-feather';
 
 import type { Request } from 'utils';
 
@@ -7,21 +7,26 @@ import { Code } from '../Code';
 
 interface SidebarProps {
   request: Request;
+  close: () => void;
 }
 
 const stickyTitle =
-  'sticky border-t border-white top-[calc(4rem+1px)] z-10 min-h-10 w-full pl-6 pr-2 flex items-center display-subheading uppercase text-white bg-grey-900';
+  'sticky border-t border-white top-[calc(2.5rem+1px)] z-10 min-h-10 w-full pl-6 pr-2 flex items-center display-subheading uppercase text-white bg-grey-900';
 const scrollingContent = 'table w-full';
 
 export const SidebarContent: FC<SidebarProps> = ({
   request: { requestHeaders, requestBody, responseBody, queryStringParameters, displayableUrl },
+  close,
 }) => (
   <>
-    <div className="sticky top-6 z-20 w-full border-t border-black">
-      <h3 className="min-h-10 pl-6 pr-2 py-2 flex items-center display-subheading text-white bg-grey-900">
+    <div className="sticky top-0 flex items-center z-20 w-full border-t border-black text-white bg-grey-900">
+      <h3 className="grow min-h-10 pl-6 pr-2 py-2 flex items-center display-subheading">
         <Link2 className="p-1 mr-2 shrink-0" />
         <span className="break-words">{displayableUrl.replaceAll('/', '/​')}</span>
       </h3>
+      <button type="button" className="w-10 h-10 flex items-center justify-center" onClick={close}>
+        <X />
+      </button>
     </div>
     {queryStringParameters && (
       <>

--- a/src/components/SidebarContent/SidebarContent.tsx
+++ b/src/components/SidebarContent/SidebarContent.tsx
@@ -1,5 +1,5 @@
 import type { FC } from 'react';
-import { Upload, Download, Link2, X } from 'react-feather';
+import { Upload, Download, Link2, ChevronsRight } from 'react-feather';
 
 import type { Request } from 'utils';
 
@@ -25,7 +25,7 @@ export const SidebarContent: FC<SidebarProps> = ({
         <span className="break-words">{displayableUrl.replaceAll('/', '/​')}</span>
       </h3>
       <button type="button" className="w-10 h-10 flex items-center justify-center" onClick={close}>
-        <X />
+        <ChevronsRight />
       </button>
     </div>
     {queryStringParameters && (

--- a/src/components/SidebarContent/SidebarContent.tsx
+++ b/src/components/SidebarContent/SidebarContent.tsx
@@ -9,9 +9,9 @@ interface SidebarProps {
   request: Request;
 }
 
-const stickyWrapper = 'sticky top-[calc(4rem+1px)] z-10 w-full';
 const stickyTitle =
-  'sticky border-t border-white top-[calc(4rem+1px)] z-10 h-10 pl-6 pr-2 flex items-center display-subheading uppercase text-white bg-grey-900';
+  'sticky border-t border-white top-[calc(4rem+1px)] z-10 min-h-10 w-full pl-6 pr-2 flex items-center display-subheading uppercase text-white bg-grey-900';
+const scrollingContent = 'table w-full';
 
 export const SidebarContent: FC<SidebarProps> = ({
   request: { requestHeaders, requestBody, responseBody, queryStringParameters, displayableUrl },
@@ -24,40 +24,40 @@ export const SidebarContent: FC<SidebarProps> = ({
       </h3>
     </div>
     {queryStringParameters && (
-      <div className={stickyWrapper}>
+      <>
         <h3 className={stickyTitle}>
           <Upload className="p-1 mr-2" />
           Query String Parameters
         </h3>
-        <Code code={queryStringParameters} />
-      </div>
+        <Code code={queryStringParameters} className={scrollingContent} />
+      </>
     )}
     {requestHeaders.length > 0 && (
-      <div className={stickyWrapper}>
+      <>
         <h3 className={stickyTitle}>
           <Upload className="p-1 mr-2" />
           Request Headers
         </h3>
-        <Code code={requestHeaders} />
-      </div>
+        <Code code={requestHeaders} className={scrollingContent} />
+      </>
     )}
     {requestBody && (
-      <div className={stickyWrapper}>
+      <>
         <h3 className={stickyTitle}>
           <Upload className="p-1 mr-2" />
           Request Body
         </h3>
-        <Code code={requestBody} />
-      </div>
+        <Code code={requestBody} className={scrollingContent} />
+      </>
     )}
     {responseBody && (
-      <div className={stickyWrapper}>
+      <>
         <h3 className={stickyTitle}>
           <Download className="p-1 mr-2" />
           Response Body
         </h3>
-        <Code code={responseBody} />
-      </div>
+        <Code code={responseBody} className={scrollingContent} />
+      </>
     )}
   </>
 );

--- a/src/components/SidebarContent/SidebarContext.tsx
+++ b/src/components/SidebarContent/SidebarContext.tsx
@@ -4,7 +4,7 @@ import type { Request } from 'utils';
 
 interface Sidebar {
   selectedLine?: Request;
-  setSelectedLine: (id?: Request) => void;
+  selectLine: (id: Request) => void;
 }
 
 export const SidebarContext = createContext<Sidebar | null>(null);

--- a/src/components/Tags.tsx
+++ b/src/components/Tags.tsx
@@ -57,7 +57,7 @@ export const IndexTag: FC<CustomTagProps & { index: string | null }> = ({
   </Tag>
 );
 
-export const SubPathTag: FC<CustomTagProps & { subPath: string | null }> = ({
+export const ApiSubPathTag: FC<CustomTagProps & { subPath: string | null }> = ({
   subPath,
   reversed,
   ...props

--- a/src/components/Tags.tsx
+++ b/src/components/Tags.tsx
@@ -75,6 +75,7 @@ const apiString: Record<ApiType, string> = {
   merchandising: 'merch',
   'query-categorization': 'queryCat',
   search: 'search',
+  dashboard: 'dashboard',
 };
 
 export const ApiTag: FC<CustomTagProps & { api: ApiType }> = ({ api, reversed, ...props }) => (

--- a/src/components/Tags.tsx
+++ b/src/components/Tags.tsx
@@ -53,7 +53,7 @@ export const IndexTag: FC<CustomTagProps & { index: string | null }> = ({
 }) => (
   <Tag {...props} variant="accent" title="index">
     {reversed && '!'}
-    {index ? <>index: {index}</> : 'no index'}
+    {index || 'no index'}
   </Tag>
 );
 
@@ -78,7 +78,7 @@ const apiString: Record<ApiType, string> = {
 };
 
 export const ApiTag: FC<CustomTagProps & { api: ApiType }> = ({ api, reversed, ...props }) => (
-  <Tag {...props} variant="orange" title={apiString[api]}>
+  <Tag {...props} variant="orange" title="API">
     {reversed && '!'}
     {apiString[api]}
   </Tag>

--- a/src/components/Tools.tsx
+++ b/src/components/Tools.tsx
@@ -6,7 +6,7 @@ import { Slash, Settings as Cog } from 'react-feather';
 
 import { Code } from './Code';
 
-export const AclCheck: FC = () => {
+export const Tools: FC = () => {
   const [pending, startTransition] = useTransition();
   const [appId, setAppId] = useState<string>();
   const [apiKey, setApiKey] = useState<string>();

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -10,6 +10,10 @@
     "128": "./content/icons/icon-96.png"
   },
   "devtools_page": "./pages/devtools.html",
+  "options_ui": {
+    "open_in_tab": false,
+    "page": "./pages/options.html"
+  },
   "permissions": ["storage"],
   "host_permissions": ["<all_urls>"],
   "web_accessible_resources": [

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "Algolia Analyzer",
   "description": "algolia-analyzer",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "minimum_chrome_version": "60",
   "icons": {
     "16": "./content/icons/icon-16.png",

--- a/src/pages/devtools/Page.tsx
+++ b/src/pages/devtools/Page.tsx
@@ -110,7 +110,7 @@ export const Page: FC = () => {
           {selectedLine && !sidebarOpen && (
             <aside
               className={cx(
-                `absolute top-0 right-0 z-10 transition-transform
+                `fixed top-12 right-0 z-10 transition-transform
                 text-white bg-grey-900 rounded-bl ${stl`shadow-z100`}`,
                 sidebarOpen ? 'translate-x-full' : 'translate-x-0'
               )}
@@ -127,7 +127,7 @@ export const Page: FC = () => {
           <aside
             className={cx(
               sidebarOpen ? 'translate-x-0' : 'translate-x-full',
-              `absolute top-0 right-0 w-1/2 h-[calc(100vh-3rem)] overflow-y-auto z-10
+              `fixed top-12 right-0 w-1/2 h-[calc(100vh-3rem)] overflow-y-auto z-10
               flex flex-col items-start bg-white ${stl`shadow-z100`} transition-transform`
             )}
           >

--- a/src/pages/devtools/Page.tsx
+++ b/src/pages/devtools/Page.tsx
@@ -3,9 +3,9 @@ import cx from 'classnames';
 import { type FC, useCallback, useEffect, useState } from 'react';
 import { ChevronsLeft, Slash } from 'react-feather';
 
-import { AclCheck } from 'components/AclCheck';
 import { RequestsGrid } from 'components/RequestsGrid';
 import { SidebarContent, SidebarContext } from 'components/SidebarContent';
+import { Tools } from 'components/Tools';
 import { requestBody } from 'models/RequestBody';
 import { responseBody } from 'models/ResponseBody';
 import {
@@ -103,7 +103,7 @@ export const Page: FC = () => {
               className={`sticky top-0 z-10 pt-4 mb-4 pl-[calc(25%-62px)] px-[calc(0.5rem+3px)] bg-grey-100 ${stl`shadow-z100`}`}
               tabs={[
                 { label: 'Network', content: <RequestsGrid requests={requests} /> },
-                { label: 'Tools', content: <AclCheck /> },
+                { label: 'Tools', content: <Tools /> },
               ]}
             />
           </section>

--- a/src/pages/devtools/Page.tsx
+++ b/src/pages/devtools/Page.tsx
@@ -110,7 +110,7 @@ export const Page: FC = () => {
           {selectedLine && !sidebarOpen && (
             <aside
               className={cx(
-                `absolute top-0 right-0 z-10
+                `absolute top-0 right-0 z-10 transition-transform
                 text-white bg-grey-900 rounded-bl ${stl`shadow-z100`}`,
                 sidebarOpen ? 'translate-x-full' : 'translate-x-0'
               )}
@@ -122,13 +122,6 @@ export const Page: FC = () => {
               >
                 <ChevronsLeft />
               </button>
-              {/* <IconButton
-                title="open sidebar"
-                icon={ChevronsLeft}
-                size="large"
-                variant="subtle"
-                onClick={(): void => setSidebarOpen(true)}
-              /> */}
             </aside>
           )}
           <aside

--- a/src/pages/options.html
+++ b/src/pages/options.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Algolia Analyzer</title>
+  </head>
+  <body>
+    <script src="./options/index.tsx" type="module"></script>
+    <div id="root"></div>
+  </body>
+</html>

--- a/src/pages/options/Page.tsx
+++ b/src/pages/options/Page.tsx
@@ -1,0 +1,35 @@
+import { Toggle, stl } from '@algolia/satellite';
+import cx from 'classnames';
+import { useState, type FC, useEffect, type ChangeEvent } from 'react';
+import { Loader } from 'react-feather';
+
+import { isDashboardApiActive, saveDashboardApiActive } from 'utils';
+
+export const Page: FC = () => {
+  const [dashboardSate, setDashboardState] = useState<boolean>();
+
+  const updateDashboardApiActive = async (e: ChangeEvent<HTMLInputElement>): Promise<void> => {
+    const value = Boolean(e.currentTarget.checked);
+    await saveDashboardApiActive(value);
+    setDashboardState(value);
+  };
+
+  useEffect(() => {
+    const getValue = async (): Promise<void> => {
+      setDashboardState(await isDashboardApiActive());
+    };
+    getValue();
+  }, []);
+
+  return isDashboardApiActive !== undefined ? (
+    <section className={cx(stl`display-body`, 'p-6 space-y-3')}>
+      <h2 className={stl`display-heading`}>Optional APIs to watch</h2>
+      <div className="flex items-center space-x-3">
+        <span>Dashboard API</span>
+        <Toggle checked={dashboardSate} onChange={updateDashboardApiActive} />
+      </div>
+    </section>
+  ) : (
+    <Loader className="mx-auto my-10 animate-spin" />
+  );
+};

--- a/src/pages/options/Page.tsx
+++ b/src/pages/options/Page.tsx
@@ -23,7 +23,7 @@ export const Page: FC = () => {
 
   return isDashboardApiActive !== undefined ? (
     <section className={cx(stl`display-body`, 'p-6 space-y-3')}>
-      <h2 className={stl`display-heading`}>Optional APIs to watch</h2>
+      <h2 className={stl`display-heading`}>Optional APIs to capture:</h2>
       <div className="flex items-center space-x-3">
         <span>Dashboard API</span>
         <Toggle checked={dashboardSate} onChange={updateDashboardApiActive} />

--- a/src/pages/options/index.tsx
+++ b/src/pages/options/index.tsx
@@ -1,0 +1,7 @@
+import ReactDOM from 'react-dom/client';
+
+import { Page } from './Page';
+import 'content/tailwind.css';
+import '@algolia/satellite/satellite.min.css';
+
+ReactDOM.createRoot(document.getElementById('root')!).render(<Page />);

--- a/src/utils/Request.ts
+++ b/src/utils/Request.ts
@@ -1,6 +1,7 @@
 export type ApiType =
   | 'analytics'
   | 'automation'
+  | 'dashboard'
   | 'insights'
   | 'merchandising'
   | 'query-categorization'

--- a/src/utils/Request.ts
+++ b/src/utils/Request.ts
@@ -14,7 +14,7 @@ export interface Request {
   time: number;
   cluster?: string;
   api: ApiType;
-  subPath: string | null;
+  apiSubPath: string | null;
   index: string | null;
   queryStringParameters: Record<string, string>;
   requestBody: unknown | undefined;

--- a/src/utils/__tests__/getUrlData.test.ts
+++ b/src/utils/__tests__/getUrlData.test.ts
@@ -90,6 +90,19 @@ describe('getUrlData', () => {
         displayableUrl: 'f4t6cuv2ah.algolia.net/1/indexes/products/settings',
       });
     });
+
+    it('/indexes/*/task/{id}', () => {
+      expect(
+        getUrlData(new URL('https://f4t6cuv2ah.algolia.net/1/indexes/products/task/5260335001'))
+      ).toEqual({
+        api: 'search',
+        cluster: 'f4t6cuv2ah',
+        apiSubPath: 'task/{id}',
+        index: 'products',
+        queryStringParameters: {},
+        displayableUrl: 'f4t6cuv2ah.algolia.net/1/indexes/products/task/5260335001',
+      });
+    });
   });
 
   describe('analytics', () => {

--- a/src/utils/__tests__/getUrlData.test.ts
+++ b/src/utils/__tests__/getUrlData.test.ts
@@ -6,7 +6,7 @@ describe('getUrlData', () => {
       expect(getUrlData(new URL('https://f4t6cuv2ah.algolia.net/1/indexes/*/top'))).toEqual({
         api: 'search',
         cluster: 'f4t6cuv2ah',
-        subPath: 'top',
+        apiSubPath: 'top',
         index: '*',
         queryStringParameters: {},
         displayableUrl: 'f4t6cuv2ah.algolia.net/1/indexes/*/top',
@@ -19,7 +19,7 @@ describe('getUrlData', () => {
       ).toEqual({
         api: 'search',
         cluster: 'f4t6cuv2ah',
-        subPath: 'indexes',
+        apiSubPath: 'indexes',
         index: null,
         queryStringParameters: { prefix: 'products', page: '0' },
         displayableUrl: 'f4t6cuv2ah.algolia.net/1/indexes',
@@ -30,7 +30,7 @@ describe('getUrlData', () => {
       expect(getUrlData(new URL('https://f4t6cuv2ah.algolia.net/1/indexes/*/queries'))).toEqual({
         api: 'search',
         cluster: 'f4t6cuv2ah',
-        subPath: 'queries',
+        apiSubPath: 'queries',
         index: '*',
         queryStringParameters: {},
         displayableUrl: 'f4t6cuv2ah.algolia.net/1/indexes/*/queries',
@@ -43,7 +43,7 @@ describe('getUrlData', () => {
       ).toEqual({
         api: 'search',
         cluster: 'f4t6cuv2ah',
-        subPath: 'rules/search',
+        apiSubPath: 'rules/search',
         index: 'products',
         queryStringParameters: {},
         displayableUrl: 'f4t6cuv2ah.algolia.net/1/indexes/products/rules/search',
@@ -58,7 +58,7 @@ describe('getUrlData', () => {
       ).toEqual({
         api: 'search',
         cluster: 'f4t6cuv2ah',
-        subPath: 'rules/{id}',
+        apiSubPath: 'rules/{id}',
         index: 'products',
         queryStringParameters: {},
         displayableUrl: 'f4t6cuv2ah.algolia.net/1/indexes/products/rules/qr-1676451640489',
@@ -71,7 +71,7 @@ describe('getUrlData', () => {
       ).toEqual({
         api: 'search',
         cluster: 'f4t6cuv2ah',
-        subPath: 'synonyms/search',
+        apiSubPath: 'synonyms/search',
         index: 'products',
         queryStringParameters: {},
         displayableUrl: 'f4t6cuv2ah.algolia.net/1/indexes/products/synonyms/search',
@@ -84,7 +84,7 @@ describe('getUrlData', () => {
       ).toEqual({
         api: 'search',
         cluster: 'f4t6cuv2ah',
-        subPath: 'settings',
+        apiSubPath: 'settings',
         index: 'products',
         queryStringParameters: {},
         displayableUrl: 'f4t6cuv2ah.algolia.net/1/indexes/products/settings',
@@ -103,7 +103,7 @@ describe('getUrlData', () => {
       ).toEqual({
         api: 'analytics',
         cluster: 'de',
-        subPath: 'tags',
+        apiSubPath: 'tags',
         index: 'products',
         queryStringParameters: {
           index: 'products',
@@ -121,7 +121,7 @@ describe('getUrlData', () => {
       ).toEqual({
         api: 'analytics',
         cluster: 'de',
-        subPath: 'status',
+        apiSubPath: 'status',
         index: 'products',
         queryStringParameters: { index: 'products' },
         displayableUrl: 'analytics.de.algolia.com/2/status',
@@ -138,7 +138,7 @@ describe('getUrlData', () => {
       ).toEqual({
         api: 'analytics',
         cluster: 'de',
-        subPath: 'categories/count',
+        apiSubPath: 'categories/count',
         index: 'products',
         queryStringParameters: {
           index: 'products',
@@ -160,7 +160,7 @@ describe('getUrlData', () => {
       ).toEqual({
         api: 'analytics',
         cluster: 'de',
-        subPath: 'categories',
+        apiSubPath: 'categories',
         index: 'products',
         queryStringParameters: {
           index: 'products',
@@ -180,7 +180,7 @@ describe('getUrlData', () => {
       expect(getUrlData(new URL('https://analytics.de.algolia.com/2/abtests'))).toEqual({
         api: 'analytics',
         cluster: 'de',
-        subPath: 'abtests',
+        apiSubPath: 'abtests',
         index: null,
         queryStringParameters: {},
         displayableUrl: 'analytics.de.algolia.com/2/abtests',
@@ -195,7 +195,7 @@ describe('getUrlData', () => {
       ).toEqual({
         api: 'query-categorization',
         cluster: 'de',
-        subPath: 'predictions-bins',
+        apiSubPath: 'predictions-bins',
         index: null,
         queryStringParameters: {},
         displayableUrl: 'query-categorization.de.algolia.com/1/predictions-bins',
@@ -206,7 +206,7 @@ describe('getUrlData', () => {
       expect(getUrlData(new URL('https://query-categorization.de.algolia.com/1/configs'))).toEqual({
         api: 'query-categorization',
         cluster: 'de',
-        subPath: 'configs',
+        apiSubPath: 'configs',
         index: null,
         queryStringParameters: {},
         displayableUrl: 'query-categorization.de.algolia.com/1/configs',
@@ -219,7 +219,7 @@ describe('getUrlData', () => {
       ).toEqual({
         api: 'query-categorization',
         cluster: 'de',
-        subPath: 'status',
+        apiSubPath: 'status',
         index: 'products',
         queryStringParameters: {},
         displayableUrl: 'query-categorization.de.algolia.com/1/status/products',
@@ -232,7 +232,7 @@ describe('getUrlData', () => {
       ).toEqual({
         api: 'query-categorization',
         cluster: 'de',
-        subPath: 'taxonomy',
+        apiSubPath: 'taxonomy',
         index: 'products',
         queryStringParameters: {},
         displayableUrl: 'query-categorization.de.algolia.com/1/taxonomy/products',
@@ -251,7 +251,7 @@ describe('getUrlData', () => {
       ).toEqual({
         api: 'merchandising',
         cluster: 'staging',
-        subPath: 'indexes/custom-rankings',
+        apiSubPath: 'indexes/custom-rankings',
         index: 'products',
         queryStringParameters: {},
         displayableUrl:
@@ -265,7 +265,7 @@ describe('getUrlData', () => {
       expect(getUrlData(new URL('https://automation.de.algolia.com/1/indices'))).toEqual({
         api: 'automation',
         cluster: 'de',
-        subPath: 'indices',
+        apiSubPath: 'indices',
         index: null,
         queryStringParameters: {},
         displayableUrl: 'automation.de.algolia.com/1/indices',
@@ -278,7 +278,7 @@ describe('getUrlData', () => {
       ).toEqual({
         api: 'automation',
         cluster: 'de',
-        subPath: 'synonyms/count',
+        apiSubPath: 'synonyms/count',
         index: 'products',
         queryStringParameters: {},
         displayableUrl: 'automation.de.algolia.com/1/synonyms/products/count',
@@ -291,7 +291,7 @@ describe('getUrlData', () => {
       ).toEqual({
         api: 'automation',
         cluster: 'de',
-        subPath: 'synonyms',
+        apiSubPath: 'synonyms',
         index: 'products',
         queryStringParameters: { status: 'pending' },
         displayableUrl: 'automation.de.algolia.com/1/synonyms/products',
@@ -310,7 +310,7 @@ describe('getUrlData', () => {
       ).toEqual({
         api: 'insights',
         cluster: 'de',
-        subPath: 'metrics',
+        apiSubPath: 'metrics',
         index: 'products',
         queryStringParameters: {
           startDate: '2023-04-06T00:00:00.000Z',

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -4,4 +4,8 @@ export const urlPattern = new URLPattern({
 export const urlPattern2 = new URLPattern({
   hostname: '(merchandising-staging|analytics|automation|query-categorization).*.algolia.com',
 });
+export const urlPattern3 = new URLPattern({
+  hostname: '(beta-dashboard|dashboard).algolia.com',
+  pathname: '/api/*',
+});
 export const requestHeaderFilter = 'x-algolia-';

--- a/src/utils/dashboardApiActive.ts
+++ b/src/utils/dashboardApiActive.ts
@@ -1,0 +1,10 @@
+const dashboardApiActive = 'dashboardApiActive';
+
+export const isDashboardApiActive = async (): Promise<boolean> => {
+  const value = await chrome.storage.local.get(dashboardApiActive);
+  return Boolean(value[dashboardApiActive]);
+};
+
+export const saveDashboardApiActive = async (value: boolean): Promise<void> => {
+  await chrome.storage.local.set({ [dashboardApiActive]: value });
+};

--- a/src/utils/getUrlData.ts
+++ b/src/utils/getUrlData.ts
@@ -3,7 +3,7 @@ import { spliceItemAt } from './spliceItemAt';
 
 export type UrlData = Pick<
   Request,
-  'api' | 'cluster' | 'displayableUrl' | 'index' | 'queryStringParameters' | 'subPath'
+  'api' | 'apiSubPath' | 'cluster' | 'displayableUrl' | 'index' | 'queryStringParameters'
 >;
 
 const getApiPathCluster = (url: URL): Pick<UrlData, 'api' | 'cluster'> & { apiPath: string } => {
@@ -61,7 +61,7 @@ const getIndexAndSubPath = (
   api: ApiType,
   apiPath: string,
   searchParams: URLSearchParams
-): Pick<UrlData, 'index' | 'queryStringParameters' | 'subPath'> => {
+): Pick<UrlData, 'apiSubPath' | 'index' | 'queryStringParameters'> => {
   const queryStringParameters = getQueryStringParameters(searchParams);
 
   const [_slash, version, ...apiPathParts] = apiPath.split('/');
@@ -69,7 +69,7 @@ const getIndexAndSubPath = (
     apiPathParts.unshift(version);
   }
 
-  let subPath: UrlData['subPath'] = apiPathParts.join('/');
+  let apiSubPath: UrlData['apiSubPath'] = apiPathParts.join('/');
   let index: UrlData['index'] = null;
 
   switch (api) {
@@ -83,7 +83,7 @@ const getIndexAndSubPath = (
     case 'insights':
     case 'automation': {
       const { array, item } = spliceItemAt(apiPathParts, 1, null);
-      subPath = array.join('/');
+      apiSubPath = array.join('/');
       index = item ?? queryStringParameters.index ?? null;
       break;
     }
@@ -97,7 +97,7 @@ const getIndexAndSubPath = (
         array.splice(1);
         array.push('{id}');
       }
-      subPath = array.join('/');
+      apiSubPath = array.join('/');
       index = item;
       break;
     }
@@ -105,12 +105,12 @@ const getIndexAndSubPath = (
       break;
   }
 
-  return { index, subPath, queryStringParameters };
+  return { index, apiSubPath, queryStringParameters };
 };
 
 export const getUrlData = (url: URL): UrlData => {
   const { api, cluster, apiPath } = getApiPathCluster(url);
-  const { index, subPath, queryStringParameters } = getIndexAndSubPath(
+  const { index, apiSubPath, queryStringParameters } = getIndexAndSubPath(
     api,
     apiPath,
     url.searchParams
@@ -119,7 +119,7 @@ export const getUrlData = (url: URL): UrlData => {
   return {
     api,
     cluster,
-    subPath,
+    apiSubPath,
     displayableUrl: `${url.host}${url.pathname}`,
     index,
     queryStringParameters,

--- a/src/utils/getUrlData.ts
+++ b/src/utils/getUrlData.ts
@@ -93,7 +93,7 @@ const getIndexAndSubPath = (
       if (array[0] === 'indexes' && array.length > 1) {
         array.splice(0, 1);
       }
-      if (array[0] === 'rules' && array[1] !== 'search') {
+      if (['rules', 'task'].includes(array[0]) && array[1] !== 'search') {
         array.splice(1);
         array.push('{id}');
       }

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -3,3 +3,4 @@ export * from './getUrlData';
 export * from './localStorage';
 export * from './Request';
 export * from './safeJsonParse';
+export * from './dashboardApiActive';

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -5,11 +5,7 @@ module.exports = {
   content: ['./src/**/*.html', './src/**/*.ts', './src/**/*.tsx'],
   theme: {
     ...satellite.theme,
-    extends: {
-      transitionProperty: {
-        width: 'width',
-      },
-    },
+    extends: {},
   },
   plugins: [],
 };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "include": ["src", "typings"],
+  "include": ["src", "typings", ".eslintrc.js"],
   "compilerOptions": {
     "target": "esnext",
     "module": "esnext",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2854,6 +2854,16 @@
     "@typescript-eslint/typescript-estree" "5.23.0"
     debug "^4.3.2"
 
+"@typescript-eslint/parser@^5.61.0":
+  version "5.61.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-5.61.0.tgz#7fbe3e2951904bb843f8932ebedd6e0635bffb70"
+  integrity sha512-yGr4Sgyh8uO6fSi9hw3jAFXNBHbCtKKFMdX2IkT3ZqpKmtAq3lHS4ixB/COFuAIJpwl9/AqF7j72ZDWYKmIfvg==
+  dependencies:
+    "@typescript-eslint/scope-manager" "5.61.0"
+    "@typescript-eslint/types" "5.61.0"
+    "@typescript-eslint/typescript-estree" "5.61.0"
+    debug "^4.3.4"
+
 "@typescript-eslint/scope-manager@5.23.0":
   version "5.23.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-5.23.0.tgz#4305e61c2c8e3cfa3787d30f54e79430cc17ce1b"
@@ -2861,6 +2871,14 @@
   dependencies:
     "@typescript-eslint/types" "5.23.0"
     "@typescript-eslint/visitor-keys" "5.23.0"
+
+"@typescript-eslint/scope-manager@5.61.0":
+  version "5.61.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-5.61.0.tgz#b670006d069c9abe6415c41f754b1b5d949ef2b2"
+  integrity sha512-W8VoMjoSg7f7nqAROEmTt6LoBpn81AegP7uKhhW5KzYlehs8VV0ZW0fIDVbcZRcaP3aPSW+JZFua+ysQN+m/Nw==
+  dependencies:
+    "@typescript-eslint/types" "5.61.0"
+    "@typescript-eslint/visitor-keys" "5.61.0"
 
 "@typescript-eslint/type-utils@5.23.0":
   version "5.23.0"
@@ -2876,6 +2894,11 @@
   resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-5.23.0.tgz#8733de0f58ae0ed318dbdd8f09868cdbf9f9ad09"
   integrity sha512-NfBsV/h4dir/8mJwdZz7JFibaKC3E/QdeMEDJhiAE3/eMkoniZ7MjbEMCGXw6MZnZDMN3G9S0mH/6WUIj91dmw==
 
+"@typescript-eslint/types@5.61.0":
+  version "5.61.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-5.61.0.tgz#e99ff11b5792d791554abab0f0370936d8ca50c0"
+  integrity sha512-ldyueo58KjngXpzloHUog/h9REmHl59G1b3a5Sng1GfBo14BkS3ZbMEb3693gnP1k//97lh7bKsp6/V/0v1veQ==
+
 "@typescript-eslint/typescript-estree@5.23.0":
   version "5.23.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-5.23.0.tgz#dca5f10a0a85226db0796e8ad86addc9aee52065"
@@ -2887,6 +2910,19 @@
     globby "^11.0.4"
     is-glob "^4.0.3"
     semver "^7.3.5"
+    tsutils "^3.21.0"
+
+"@typescript-eslint/typescript-estree@5.61.0":
+  version "5.61.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-5.61.0.tgz#4c7caca84ce95bb41aa585d46a764bcc050b92f3"
+  integrity sha512-Fud90PxONnnLZ36oR5ClJBLTLfU4pIWBmnvGwTbEa2cXIqj70AEDEmOmpkFComjBZ/037ueKrOdHuYmSFVD7Rw==
+  dependencies:
+    "@typescript-eslint/types" "5.61.0"
+    "@typescript-eslint/visitor-keys" "5.61.0"
+    debug "^4.3.4"
+    globby "^11.1.0"
+    is-glob "^4.0.3"
+    semver "^7.3.7"
     tsutils "^3.21.0"
 
 "@typescript-eslint/utils@5.23.0", "@typescript-eslint/utils@^5.13.0":
@@ -2908,6 +2944,14 @@
   dependencies:
     "@typescript-eslint/types" "5.23.0"
     eslint-visitor-keys "^3.0.0"
+
+"@typescript-eslint/visitor-keys@5.61.0":
+  version "5.61.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-5.61.0.tgz#c79414fa42158fd23bd2bb70952dc5cdbb298140"
+  integrity sha512-50XQ5VdbWrX06mQXhy93WywSFZZGsv3EOjq+lqp6WC2t+j3mb6A9xYVdrRxafvK88vg9k9u+CT4l6D8PEatjKg==
+  dependencies:
+    "@typescript-eslint/types" "5.61.0"
+    eslint-visitor-keys "^3.3.0"
 
 "@xobotyi/scrollbar-width@1.9.5":
   version "1.9.5"
@@ -4699,7 +4743,7 @@ globalyzer@0.1.0:
   resolved "https://registry.yarnpkg.com/globalyzer/-/globalyzer-0.1.0.tgz#cb76da79555669a1519d5a8edf093afaa0bf1465"
   integrity sha512-40oNTM9UfG6aBmuKxk/giHn5nQ8RVz/SS4Ir6zgzOv9/qC3kKZ9v4etGTcJbEl/NyVQH7FGU7d+X1egr57Md2Q==
 
-globby@^11.0.4:
+globby@^11.0.4, globby@^11.1.0:
   version "11.1.0"
   resolved "https://registry.yarnpkg.com/globby/-/globby-11.1.0.tgz#bd4be98bb042f83d796f7e3811991fbe82a0d34b"
   integrity sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==


### PR DESCRIPTION
- add some linting rules
- extract url splitting logic
- handle tasks requests
- improve sidebar
  - titles are sticky but content is scrolling
  - new open/close design: new button(s) + positioning of those buttons
  - it can re-opened when closed
  - sidebar now goes over content instead of pushing it
  - animated open/close
- in tools, when there is `listIndexes` ACL → autocomplete on the index field
- where code is displayed, copying string now doesn't include double quotes
- add options page (+ link in header)
  - contains a setting to enable capturing Dashboard API calls
- captures Dashboard API calls when the option ☝️ is enabled