### PR TITLE
fix: when saving filter options, disable the button afterwards

### DIFF
--- a/src/components/RequestsGrid/RequestsGrid.tsx
+++ b/src/components/RequestsGrid/RequestsGrid.tsx
@@ -61,9 +61,13 @@ export const RequestsGrid: FC<RequestsGridProps> = ({ requests }) => {
 
   const saveDefaultOptions = async (): Promise<void> => {
     setIsSaving(true);
+    const newGeneralOptions = selectedGeneralOptions;
+    const newUrlOptions = selectedUrlOptions;
     try {
-      await setLocalStorageValue(generalOptionsKey, selectedGeneralOptions);
-      await setLocalStorageValue(urlOptionsKey, selectedUrlOptions);
+      await setLocalStorageValue(generalOptionsKey, newGeneralOptions);
+      setDefaultGeneralOptions(newGeneralOptions);
+      await setLocalStorageValue(urlOptionsKey, newUrlOptions);
+      setDefaultUrlOptions(newUrlOptions);
     } finally {
       setIsSaving(false);
     }


### PR DESCRIPTION
by properly resetting the "currently saved" state