### PR TITLE
fix: badge overflow

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "devDependencies": {
     "@algolia/client-search": "^4.20.0",
     "@algolia/eslint-plugin-satellite": "^4.4.0",
-    "@algolia/satellite": "1.0.0-beta.172",
+    "@algolia/satellite": "1.0.0-beta.178",
     "@parcel/config-webextension": "^2.10.3",
     "@parcel/validator-typescript": "^2.10.3",
     "@swc/core": "^1.3.100",

--- a/src/components/SidebarContent/LibVersions/TagVersion.tsx
+++ b/src/components/SidebarContent/LibVersions/TagVersion.tsx
@@ -46,7 +46,11 @@ export const TagVersion: FC<TagVersionProps> = ({ packageName, currentVersion })
   }, [currentVersion.major, currentVersion.minor, currentVersion.patch, yarn]);
 
   return yarn ? (
-    <TooltipWrapper content={`latest version: ${yarn.version}`} hideDelay={0} side="top">
+    <TooltipWrapper
+      content={`latest version: ${yarn.version} (current: ${currentVersion.version})`}
+      hideDelay={0}
+      side="top"
+    >
       <Badge variant={color} icon={icon[color]}>
         {packageName}
         {yarnName !== packageName && <> ({yarnName})</>} {currentVersion.version}

--- a/src/components/SidebarContent/LibVersions/index.tsx
+++ b/src/components/SidebarContent/LibVersions/index.tsx
@@ -10,7 +10,10 @@ interface LibVersionProps {
 export const LibVersions: FC<LibVersionProps> = ({ algoliaAgent }) => {
   const packagesInfo = useMemo(() => getPackagesInfo(algoliaAgent), [algoliaAgent]);
   return (
-    <div className="space-x-2 space-y-2 [&>*:first-child]:ml-2 mb-2 ml-4">
+    <div
+      className="space-x-2 space-y-2 [&>*:first-child]:ml-2 mb-2 ml-4 [&>*]:max-w-[inherit]"
+      style={{ maxWidth: '-webkit-fill-available' }}
+    >
       {packagesInfo.map(({ name, ...currentVersion }) => (
         <TagVersion key={name} packageName={name} currentVersion={currentVersion} />
       ))}

--- a/yarn.lock
+++ b/yarn.lock
@@ -111,21 +111,23 @@
   dependencies:
     "@algolia/requester-common" "4.20.0"
 
-"@algolia/satellite@1.0.0-beta.172":
-  version "1.0.0-beta.172"
-  resolved "https://registry.yarnpkg.com/@algolia/satellite/-/satellite-1.0.0-beta.172.tgz#875a6dd94ab3c2e2dc60f3c79002449f9c371fc0"
-  integrity sha512-c8G98sFnyJSPOEsc+APAIV+gY8C8IXjct0LRdKRYVDJOw4TRZrWQLEXKRUz/jhqSjT8RVd9/iXRc24pyvrqoKA==
+"@algolia/satellite@1.0.0-beta.178":
+  version "1.0.0-beta.178"
+  resolved "https://registry.yarnpkg.com/@algolia/satellite/-/satellite-1.0.0-beta.178.tgz#fcb5bd551b28360f73d46bf5549774fdca5a9b57"
+  integrity sha512-bjzRP5cx+DC+sLntm0ckft9/7+LQgbzYiCiXX5LAk8HRebXTBPVod/3nbZuljAN7thhILKAg5sqAqwJdzi1seQ==
   dependencies:
     "@babel/runtime" "^7.21.0"
     "@popperjs/core" "^2.4.4"
     "@radix-ui/react-avatar" "^1.0.3"
     "@radix-ui/react-dialog" "^1.0.4"
+    "@radix-ui/react-dropdown-menu" "^2.0.5"
     "@radix-ui/react-popover" "^1.0.7"
     "@radix-ui/react-progress" "^1.0.3"
     "@radix-ui/react-separator" "^1.0.3"
     "@radix-ui/react-slider" "^1.1.2"
     "@radix-ui/react-slot" "^1.0.2"
     "@radix-ui/react-tabs" "^1.0.4"
+    "@radix-ui/react-toast" "^1.1.5"
     "@radix-ui/react-tooltip" "^1.0.6"
     clsx "^2.0.0"
     color "^4.2.3"
@@ -135,6 +137,7 @@
     lodash "^4.17.21"
     react-day-picker "^8.0.7"
     react-dropzone "^11.5.1"
+    react-feather "^2.0.10"
     react-popper "^2.2.5"
     react-transition-group "^4.4.5"
     react-use "^15.3.8"
@@ -2844,6 +2847,20 @@
     "@radix-ui/react-use-callback-ref" "1.0.1"
     "@radix-ui/react-use-escape-keydown" "1.0.3"
 
+"@radix-ui/react-dropdown-menu@^2.0.5":
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-dropdown-menu/-/react-dropdown-menu-2.0.6.tgz#cdf13c956c5e263afe4e5f3587b3071a25755b63"
+  integrity sha512-i6TuFOoWmLWq+M/eCLGd/bQ2HfAX1RJgvrBQ6AQLmzfvsLdefxbWu8G9zczcPFfcSPehz9GcpF6K9QYreFV8hA==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/primitive" "1.0.1"
+    "@radix-ui/react-compose-refs" "1.0.1"
+    "@radix-ui/react-context" "1.0.1"
+    "@radix-ui/react-id" "1.0.1"
+    "@radix-ui/react-menu" "2.0.6"
+    "@radix-ui/react-primitive" "1.0.3"
+    "@radix-ui/react-use-controllable-state" "1.0.1"
+
 "@radix-ui/react-focus-guards@1.0.1":
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-focus-guards/-/react-focus-guards-1.0.1.tgz#1ea7e32092216b946397866199d892f71f7f98ad"
@@ -2868,6 +2885,31 @@
   dependencies:
     "@babel/runtime" "^7.13.10"
     "@radix-ui/react-use-layout-effect" "1.0.1"
+
+"@radix-ui/react-menu@2.0.6":
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-menu/-/react-menu-2.0.6.tgz#2c9e093c1a5d5daa87304b2a2f884e32288ae79e"
+  integrity sha512-BVkFLS+bUC8HcImkRKPSiVumA1VPOOEC5WBMiT+QAVsPzW1FJzI9KnqgGxVDPBcql5xXrHkD3JOVoXWEXD8SYA==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/primitive" "1.0.1"
+    "@radix-ui/react-collection" "1.0.3"
+    "@radix-ui/react-compose-refs" "1.0.1"
+    "@radix-ui/react-context" "1.0.1"
+    "@radix-ui/react-direction" "1.0.1"
+    "@radix-ui/react-dismissable-layer" "1.0.5"
+    "@radix-ui/react-focus-guards" "1.0.1"
+    "@radix-ui/react-focus-scope" "1.0.4"
+    "@radix-ui/react-id" "1.0.1"
+    "@radix-ui/react-popper" "1.1.3"
+    "@radix-ui/react-portal" "1.0.4"
+    "@radix-ui/react-presence" "1.0.1"
+    "@radix-ui/react-primitive" "1.0.3"
+    "@radix-ui/react-roving-focus" "1.0.4"
+    "@radix-ui/react-slot" "1.0.2"
+    "@radix-ui/react-use-callback-ref" "1.0.1"
+    aria-hidden "^1.1.1"
+    react-remove-scroll "2.5.5"
 
 "@radix-ui/react-popover@^1.0.7":
   version "1.0.7"
@@ -3006,6 +3048,25 @@
     "@radix-ui/react-primitive" "1.0.3"
     "@radix-ui/react-roving-focus" "1.0.4"
     "@radix-ui/react-use-controllable-state" "1.0.1"
+
+"@radix-ui/react-toast@^1.1.5":
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-toast/-/react-toast-1.1.5.tgz#f5788761c0142a5ae9eb97f0051fd3c48106d9e6"
+  integrity sha512-fRLn227WHIBRSzuRzGJ8W+5YALxofH23y0MlPLddaIpLpCDqdE0NZlS2NRQDRiptfxDeeCjgFIpexB1/zkxDlw==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/primitive" "1.0.1"
+    "@radix-ui/react-collection" "1.0.3"
+    "@radix-ui/react-compose-refs" "1.0.1"
+    "@radix-ui/react-context" "1.0.1"
+    "@radix-ui/react-dismissable-layer" "1.0.5"
+    "@radix-ui/react-portal" "1.0.4"
+    "@radix-ui/react-presence" "1.0.1"
+    "@radix-ui/react-primitive" "1.0.3"
+    "@radix-ui/react-use-callback-ref" "1.0.1"
+    "@radix-ui/react-use-controllable-state" "1.0.1"
+    "@radix-ui/react-use-layout-effect" "1.0.1"
+    "@radix-ui/react-visually-hidden" "1.0.3"
 
 "@radix-ui/react-tooltip@^1.0.6":
   version "1.0.7"


### PR DESCRIPTION
- upgrade `@algolia/satellite`
- limit `LibVersions` component's max width to available content
- update lib tooltip to also show current version (in case of overflow)